### PR TITLE
feat: allow alternate VERTICA_SDK_PATH

### DIFF
--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+VERTICA_SDK_PATH=${VERTICA_SDK_PATH:-"/opt/vertica/sdk"}
+
 _b_env=${1:-centos8.Dockerfile}
 errout() {
   _r=$1
@@ -9,7 +11,7 @@ errout() {
 BUILDER_IMAGE="vertica-builder-hll-druid:local"
 BUILDER_INSTANCE_NAME="vbuilder-hll-druid"
 docker build -f ${_b_env} -t ${BUILDER_IMAGE} .
-test -f /opt/vertica/sdk/include/BuildInfo.h || errout 30 "Vertica SDK is missing. Put it in /opt/vertica/sdk so that /opt/vertica/sdk/include/BuildInfo.h exists"
+test -f ${VERTICA_SDK_PATH}/include/BuildInfo.h || errout 30 "Vertica SDK is missing. Put it in ${VERTICA_SDK_PATH} so that ${VERTICA_SDK_PATH}/include/BuildInfo.h exists"
 
 rm -rf build
 mkdir -p build
@@ -17,7 +19,7 @@ docker kill ${BUILDER_INSTANCE_NAME} || true
 sleep 1
 docker rm ${BUILDER_INSTANCE_NAME} || true
 sleep 1
-docker run --rm --name ${BUILDER_INSTANCE_NAME} -v=$PWD/SOURCES:/sources -v=/opt/vertica/sdk:/opt/vertica/sdk  -d $BUILDER_IMAGE sleep 3600
+docker run --rm --name ${BUILDER_INSTANCE_NAME} -v=$PWD/SOURCES:/sources -v=${VERTICA_SDK_PATH}:/opt/vertica/sdk  -d $BUILDER_IMAGE sleep 3600
 echo "Run docker exec -ti ${BUILDER_INSTANCE_NAME} bash # now"
 echo "Then, you may run the following to build"
 echo "cmake /sources; make clean; make"


### PR DESCRIPTION
When using Docker, allow using another path for our local copy of the Vertica SDK